### PR TITLE
Fix gcc version to fix c++ standard mismatch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
 - notebook
 - xeus-cling
+- gcc=9.4.0
 - xproperty=0.10.1
 - widgetsnbextension
 - xwidgets


### PR DESCRIPTION
With the proposed `environment.yml`, I had gcc 9.5.0 installed and an error:
```
Warning in cling::IncrementalParser::CheckABICompatibility():
  Possible C++ standard library mismatch, compiled with __GLIBCXX__ '20191114'
  Extraction of runtime standard library version was: '20220527'
```
cf. https://github.com/jupyter-xeus/xeus-cling/issues/415#issuecomment-1227200351

I fixed it by setting `gcc=9.4.0` in `environment.yml`